### PR TITLE
Updated version to support newer python versions 3.8 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-    - "3.5"
+    - "3.8"
 install:
     - pip install coveralls
 script: "./uranium test"

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-aiographite
+aiographite 
 ===========
 
 .. image:: https://travis-ci.org/zillow/aiographite.svg?branch=master

--- a/aiographite/aiographite.py
+++ b/aiographite/aiographite.py
@@ -30,11 +30,13 @@ class AIOGraphite:
     """
     AIOGraphite is a Graphite client class, ultilizing asyncio,
     designed to help Graphite users to send data into graphite easily.
+
+    Loop parameter is removed from this version as in python 3.10 and above parameter is removed
     """
 
     def __init__(self, graphite_server,
                  graphite_port=DEFAULT_GRAPHITE_PLAINTEXT_PORT,
-                 protocol=PlaintextProtocol(), loop=None, timeout=None):
+                 protocol=PlaintextProtocol(), timeout=None):
         if not isinstance(protocol, (PlaintextProtocol, PickleProtocol)):
             raise AioGraphiteSendException("Unsupported Protocol!")
         self._graphite_server = graphite_server
@@ -43,7 +45,6 @@ class AIOGraphite:
         self._reader, self._writer = None, None
         self._timeout = timeout
         self.protocol = protocol
-        self.loop = loop or asyncio.get_event_loop()
 
     async def __aenter__(self):
         await self._connect()
@@ -99,13 +100,10 @@ class AIOGraphite:
         try:
             self._reader, self._writer = await asyncio.open_connection(
                 self._graphite_server,
-                self._graphite_port,
-                loop=self.loop)
-        except Exception:
-            raise AioGraphiteSendException(
-                "Unable to connect to the provided server address %s:%s"
-                % self._graphite_server_address
-                )
+                self._graphite_port)
+        except Exception as e:
+            raise AioGraphiteSendException(f"Unable to connect to the provided server address "
+                                           f"{self._graphite_server_address} due to error : {e}")
 
     async def _disconnect(self) -> None:
         """

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,3 @@
-name: py35
+name: py38
 dependencies:
-    - python=3.5.1=0
+    - python=3.8.16=0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = []
 tests_require = []
 
 setup(name='aiographite',
-      version='0.1.9',
+      version='0.2.0',
       description='',
       long_description=open(README_PATH).read(),
       author='Yun Xu',
@@ -25,8 +25,9 @@ setup(name='aiographite',
           'Operating System :: POSIX :: Linux',
           'Topic :: System :: Software Distribution',
           'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
       ]
 )


### PR DESCRIPTION
Removed the loop parameter of  `asyncio.open_connection` function as it is deprecated above python 3.8 and removed from python 3.10.